### PR TITLE
feat: implement initial `create_limit_order`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,13 @@ On Starknet, the deployment process is in two steps:
 
 This demo will perform the following steps:
 
-- Declaration of the following contracts: ERC20 Token, YASFactory, YASPool, and YASRouter.
+- Declaration of the following contracts: ERC20 Token, YASFactory, YASPool,
+  and YASRouter.
 - Deployment of 2 ERC20 Tokens, YASFactory, YASPool, and YASRouter.
 - Initialization of YASPool with a 1:1 token price.
 - Execute approve() for the router to use tokens from the user.
-- Execute mint() within the range [-887220, 887220] with 2000000000000000000 tokens.
+- Execute mint() within the range [-887220, 887220] with 2000000000000000000
+  tokens.
 - Execute swap() exchanging 500000000000000000 of token 0 for token 1.
 - Display current balances of both the pool and the user.
 
@@ -230,6 +232,20 @@ PRIVATE_KEY=0x2bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a \
 STARKNET_RPC="https://rpc-goerli-1.starknet.rs/rpc/v0.4" \
 make deploy
 ```
+
+## Implementing Limit Orders
+
+### `create_limit_order`
+
+- Similar to `mint`, this function creates a limit order of `amount` between
+  `tick_lower` and `tick_lower + tick_spacing`.
+- In the `Info` and `PositionKey` struct, we add a flag `is_limit_order` to
+  differentiate if the position is a limit order. The bitmap data structure
+  allows the position to be stored in an efficient way so we don't need to
+  loop over them for each swap.
+- When a `swap` happens and the position to be filled is a limit order, the
+  liquidity is automatically withdrawn. This way the position does not get
+  unfilled if the price moves back across the tick.
 
 ## Version Specifications
 

--- a/src/contracts/yas_router.cairo
+++ b/src/contracts/yas_router.cairo
@@ -12,6 +12,13 @@ trait IYASRouter<TContractState> {
         tick_lower: i32,
         tick_upper: i32,
         amount: u128
+    ) -> (u256, u256);
+    fn create_limit_order(
+        self: @TContractState,
+        pool: ContractAddress,
+        recipient: ContractAddress,
+        tick_lower: i32,
+        amount: u128,
     );
     fn yas_mint_callback(
         ref self: TContractState, amount_0_owed: u256, amount_1_owed: u256, data: Array<felt252>
@@ -85,10 +92,23 @@ mod YASRouter {
             tick_lower: i32,
             tick_upper: i32,
             amount: u128
-        ) {
+        ) -> (u256, u256) {
             IYASPoolDispatcher { contract_address: pool }
                 .mint(
                     recipient, tick_lower, tick_upper, amount, array![get_caller_address().into()]
+                )
+        }
+
+        fn create_limit_order(
+            self: @ContractState,
+            pool: ContractAddress,
+            recipient: ContractAddress,
+            tick_lower: i32,
+            amount: u128,
+        ) {
+            IYASPoolDispatcher { contract_address: pool }
+                .create_limit_order(
+                    recipient, tick_lower, amount, array![get_caller_address().into()]
                 );
         }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -20,6 +20,7 @@ mod libraries {
     mod sqrt_price_math;
     mod tick;
     mod tick_bitmap;
+    mod errors;
 }
 
 mod numbers {

--- a/src/libraries/errors.cairo
+++ b/src/libraries/errors.cairo
@@ -1,0 +1,11 @@
+mod LiquidityError {
+    fn ZeroLiquidity() {
+        panic(array!['no liquidity'])
+    }
+}
+
+mod RangeError {
+    fn InRange() {
+        panic(array!['in range'])
+    }
+}

--- a/src/libraries/position.cairo
+++ b/src/libraries/position.cairo
@@ -3,7 +3,7 @@ use yas::numbers::signed_integer::{i32::i32, i128::i128, integer_trait::IntegerT
 
 
 // info stored for each user's position
-#[derive(Copy, Drop, Serde, starknet::Store)]
+#[derive(Copy, Drop, Serde, starknet::Store, PartialEq)]
 struct Info {
     // the amount of liquidity owned by this position
     liquidity: u128,
@@ -13,6 +13,8 @@ struct Info {
     // the fee owed to the position owner in token0/token1
     tokens_owed_0: u128,
     tokens_owed_1: u128,
+    // if position is a limit order
+    is_limit_order: bool,
 }
 
 #[derive(Copy, Drop, Hash, Serde)]
@@ -20,6 +22,7 @@ struct PositionKey {
     owner: ContractAddress,
     tick_lower: i32,
     tick_upper: i32,
+    is_limit_order: bool,
 }
 
 #[starknet::interface]
@@ -110,6 +113,10 @@ mod Position {
                 position.liquidity = liquidity_next;
             }
 
+            if position_key.is_limit_order {
+                position.is_limit_order = true;
+            }
+
             position.fee_growth_inside_0_last_X128 = fee_growth_inside_0_X128;
             position.fee_growth_inside_1_last_X128 = fee_growth_inside_1_X128;
 
@@ -130,4 +137,3 @@ mod Position {
         }
     }
 }
-

--- a/src/tests/test_libraries/test_position.cairo
+++ b/src/tests/test_libraries/test_position.cairo
@@ -27,6 +27,7 @@ mod PositionTests {
                 owner: OWNER(),
                 tick_lower: IntegerTrait::<i32>::new(0, false),
                 tick_upper: IntegerTrait::<i32>::new(10, false),
+                is_limit_order: false,
             };
 
             let info = Info {
@@ -35,6 +36,7 @@ mod PositionTests {
                 fee_growth_inside_1_last_X128: 20,
                 tokens_owed_0: 10,
                 tokens_owed_1: 10,
+                is_limit_order: false,
             };
 
             InternalImpl::set_position(ref state, position_key, info);
@@ -46,6 +48,7 @@ mod PositionTests {
             assert(position.fee_growth_inside_1_last_X128 == 20, 'fee_growth_inside_1_last_X128');
             assert(position.tokens_owed_0 == 10, 'tokens_owed_0');
             assert(position.tokens_owed_1 == 10, 'tokens_owed_1');
+            assert(position.is_limit_order == false, 'is_limit_order');
         }
         #[test]
         #[available_gas(30000000)]
@@ -56,6 +59,7 @@ mod PositionTests {
                 owner: OWNER(),
                 tick_lower: IntegerTrait::<i32>::new(0, false),
                 tick_upper: IntegerTrait::<i32>::new(10, false),
+                is_limit_order: false,
             };
 
             let position: Info = PositionImpl::get(@state, position_key);
@@ -85,6 +89,7 @@ mod PositionTests {
                 owner: OWNER(),
                 tick_lower: IntegerTrait::<i32>::new(0, false),
                 tick_upper: IntegerTrait::<i32>::new(10, false),
+                is_limit_order: false,
             };
 
             // should be zero or negative to make it panic
@@ -111,6 +116,7 @@ mod PositionTests {
                 owner: OWNER(),
                 tick_lower: IntegerTrait::<i32>::new(0, false),
                 tick_upper: IntegerTrait::<i32>::new(10, false),
+                is_limit_order: false,
             };
 
             let info = Info {
@@ -119,6 +125,7 @@ mod PositionTests {
                 fee_growth_inside_1_last_X128: 0,
                 tokens_owed_0: 10,
                 tokens_owed_1: 10,
+                is_limit_order: false,
             };
 
             InternalImpl::set_position(ref state, position_key, info);
@@ -143,6 +150,7 @@ mod PositionTests {
             assert(position.fee_growth_inside_1_last_X128 == 0, 'fee_growth_inside_1_last_X128');
             assert(position.tokens_owed_0 == 10, 'tokens_owed_0');
             assert(position.tokens_owed_1 == 10, 'tokens_owed_1');
+            assert(position.is_limit_order == false, 'is_limit_order');
         }
 
         #[test]
@@ -154,6 +162,7 @@ mod PositionTests {
                 owner: OWNER(),
                 tick_lower: IntegerTrait::<i32>::new(0, false),
                 tick_upper: IntegerTrait::<i32>::new(10, false),
+                is_limit_order: false,
             };
 
             let liquidity_delta = IntegerTrait::<i128>::new(100, false);

--- a/src/tests/test_libraries/test_swap_math.cairo
+++ b/src/tests/test_libraries/test_swap_math.cairo
@@ -19,13 +19,14 @@ mod TestSwapMath {
         use yas::tests::test_libraries::test_swap_math::TestSwapMath::expand_to_18_decimals;
 
         use yas::numbers::signed_integer::integer_trait::IntegerTrait;
+        use yas::tests::utils::constants::PoolConstants::encode_price_sqrt_1_1;
 
         // exact amount in that gets capped at price target in one for zero
         #[test]
         #[available_gas(200000000)]
         fn test_amount_in_gets_capped_at_price_target_in_one_for_zero() {
             // price is the result of encode_price_sqrt(1, 1) on v3-core typescript impl. 
-            let price = FP64x96Impl::new(79228162514264337593543950336, false);
+            let price = encode_price_sqrt_1_1();
             // price_target is the result of encode_price_sqrt(101, 100) on v3-core typescript impl. 
             let price_target = FP64x96Impl::new(79623317895830914510639640423, false);
             let liquidity: u128 = expand_to_18_decimals(2).try_into().unwrap();
@@ -59,7 +60,7 @@ mod TestSwapMath {
         #[available_gas(200000000)]
         fn test_amount_out_gets_capped_at_price_target_in_one_for_zero() {
             // price is the result of encode_price_sqrt(1, 1) on v3-core typescript impl. 
-            let price = FP64x96Impl::new(79228162514264337593543950336, false);
+            let price = encode_price_sqrt_1_1();
             // price_target is the result of encode_price_sqrt(101, 100) on v3-core typescript impl. 
             let price_target = FP64x96Impl::new(79623317895830914510639640423, false);
             let liquidity: u128 = expand_to_18_decimals(2).try_into().unwrap();
@@ -89,7 +90,7 @@ mod TestSwapMath {
         #[available_gas(200000000)]
         fn test_amount_in_that_is_fully_spent_in_one_for_zero() {
             // price is the result of encode_price_sqrt(1, 1) on v3-core typescript impl. 
-            let price = FP64x96Impl::new(79228162514264337593543950336, false);
+            let price = encode_price_sqrt_1_1();
             // price_target is the result of encode_price_sqrt(1000, 100) on v3-core typescript impl. 
             let price_target = FP64x96Impl::new(250541448375047931186413801569, false);
 
@@ -125,7 +126,7 @@ mod TestSwapMath {
         #[available_gas(200000000)]
         fn test_amount_out_that_is_fully_received_in_one_for_zero() {
             // price is the result of encode_price_sqrt(1, 1) on v3-core typescript impl. 
-            let price = FP64x96Impl::new(79228162514264337593543950336, false);
+            let price = encode_price_sqrt_1_1();
             // price_target is the result of encode_price_sqrt(10000, 100) on v3-core typescript impl. 
             let price_target = FP64x96Impl::new(792281625142643375935439503360, false);
 


### PR DESCRIPTION
This pr does the following:
- add initial implementation of `create_limit_order`
- updated README for documentation
