### PR TITLE
feat: implement `collect_limit_order`

### DIFF
--- a/src/interfaces/interface_ERC20.cairo
+++ b/src/interfaces/interface_ERC20.cairo
@@ -7,4 +7,6 @@ trait IERC20<TContractState> {
     fn transferFrom(
         ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
     ) -> bool;
+    fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
+    fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
 }

--- a/src/interfaces/interface_yas_collect_callback.cairo
+++ b/src/interfaces/interface_yas_collect_callback.cairo
@@ -1,0 +1,9 @@
+#[starknet::interface]
+trait IYASCollectCallback<TContractState> {
+    fn yas_collect_callback(
+        self: @TContractState,
+        amount_0_collected: u256,
+        amount_1_collected: u256,
+        data: Array<felt252>
+    );
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -9,6 +9,7 @@ mod interfaces {
     mod interface_ERC20;
     mod interface_yas_mint_callback;
     mod interface_yas_swap_callback;
+    mod interface_yas_collect_callback;
 }
 
 mod libraries {

--- a/src/libraries/errors.cairo
+++ b/src/libraries/errors.cairo
@@ -1,3 +1,9 @@
+mod LimitOrderError {
+    fn OrderDoesNotExist() {
+        panic(array!['limit order not found'])
+    }
+}
+
 mod LiquidityError {
     fn ZeroLiquidity() {
         panic(array!['no liquidity'])


### PR DESCRIPTION
This pr does the following:
- implement `collect_limit_order` that collects the limit order, returning the swapped amount and / or refunding any unswapped amount to the user
- add tests for collecting limit orders
- update README for documentation